### PR TITLE
Fix bug in unused variable tracking

### DIFF
--- a/expected/plpgsql_check_active.out
+++ b/expected/plpgsql_check_active.out
@@ -1066,6 +1066,7 @@ select * from plpgsql_check_function('f1()');
 (3 rows)
 
 drop function f1();
+create table f1tbl(a int, b int);
 -- unused variables
 create or replace function f1(_input1 int)
 returns table(_output1 int, _output2 int)
@@ -1077,6 +1078,7 @@ _f3 int;
 _f4 int;
 _f5 int;
 _r record;
+_tbl f1tbl;
 begin
 if true then
 	_f1 := 1;
@@ -1084,6 +1086,7 @@ end if;
 select 1, 2 into _f3, _f4;
 perform 1 where _f5 is null;
 select 1 into _r;
+select 1, 2 into _tbl;
 
 -- check that SQLSTATE and SQLERRM don't raise false positives
 begin
@@ -1100,6 +1103,7 @@ select * from plpgsql_check_function('f1(int)');
 (2 rows)
 
 drop function f1(int);
+drop table f1tbl;
 -- check that NEW and OLD are not reported unused
 create table f1tbl();
 create or replace function f1()

--- a/plpgsql_check.c
+++ b/plpgsql_check.c
@@ -1984,6 +1984,7 @@ check_row_or_rec(PLpgSQL_checkstate *cstate, PLpgSQL_row *row, PLpgSQL_rec *rec)
 
 			check_target(cstate, row->varnos[fnum]);
 		}
+		record_variable_usage(cstate, row->dno);
 	}
 	else if (rec != NULL)
 	{

--- a/sql/plpgsql_check_active.sql
+++ b/sql/plpgsql_check_active.sql
@@ -758,6 +758,8 @@ select * from plpgsql_check_function('f1()');
 
 drop function f1();
 
+create table f1tbl(a int, b int);
+
 -- unused variables
 create or replace function f1(_input1 int)
 returns table(_output1 int, _output2 int)
@@ -769,6 +771,7 @@ _f3 int;
 _f4 int;
 _f5 int;
 _r record;
+_tbl f1tbl;
 begin
 if true then
 	_f1 := 1;
@@ -776,6 +779,7 @@ end if;
 select 1, 2 into _f3, _f4;
 perform 1 where _f5 is null;
 select 1 into _r;
+select 1, 2 into _tbl;
 
 -- check that SQLSTATE and SQLERRM don't raise false positives
 begin
@@ -788,6 +792,7 @@ $$ language plpgsql;
 select * from plpgsql_check_function('f1(int)');
 
 drop function f1(int);
+drop table f1tbl;
 
 -- check that NEW and OLD are not reported unused
 create table f1tbl();


### PR DESCRIPTION
Variable usage was not tracked correctly for known rowtypes.

Per report from Steeve Lennmark.
