### PR TITLE
Fix detection of argument number

### DIFF
--- a/src/expr_walk.c
+++ b/src/expr_walk.c
@@ -593,7 +593,7 @@ check_fmt_string(const char *fmt,
 			}
 		}
 
-		if (argpos > 1)
+		if (argpos >= 1)
 		{
 			TOO_FEW_ARGUMENTS_CHECK(argpos, nargs);
 			required_nargs = -1;


### PR DESCRIPTION
Previously, this would trigger a too few arguments:
```
    perform format('%1$s %1$s', 'test');
```
While this one was fine:
```
    perform format('%1$s %2$s %2$s', 'test', 'toto');
```

With this patch, this error is gone and %1 arguments are properly checked instead of being checked as a non-numbered format placeholder.