### PR TITLE
Fix handling of dynamic query in return

### DIFF
--- a/src/stmtwalk.c
+++ b/src/stmtwalk.c
@@ -1032,6 +1032,7 @@ plpgsql_check_stmt(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt, int *closing,
 #endif
 
 										  stmt_rq->params);
+						cstate->found_return_query = true;
 					}
 				}
 				break;


### PR DESCRIPTION
The found_return_query is not set in case of a dynamic query thus a table result is marked as set.
I have tested it with the functions from #57, but could not run an installcheck (it segfaulted even without this patch)

close #57 