### PR TITLE
Add new plpgsql_check.profiler_max_shared_chunks GUC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,21 @@ Due dependencies, `shared_preload_libraries` should to contains `plpgsql` first
 The profiler is active when GUC `plpgsql_check.profiler` is on. The profiler doesn't require shared memory,
 but if there are not shared memory, then the profile is limmitted just to active session.
 
+When plpgsql_check is initialized by `shared_preload_libraries`, another GUC is
+available to configure the amount of shared memory used by the profiler:
+`plpgsql_check.profiler_max_shared_chunks`.  This defines the maximum number of
+statements chunk that can be stored in shared memory.  For each plpgsql
+function (or procedure), the whole content is split into chunks of 30
+statements.  If needed, multiple chunks can be used to store the whole content
+of a single function.  A single chunk is 1704 bytes.  The default value for
+this GUC is 15000, which should be enough for big projects containing hundred
+of thousands of statements in plpgsql, and will consume about 24MB of memory.
+If your project doesn't require that much number of chunks, you can set this
+parameter to a smaller number in order to decrease the memory usage.  The
+minimum value is 50 (which should consume about 83kB of memory), and the
+maximum value is 100000 (which should consume about 163MB of memory).  Changing
+this parameter requires a PostgreSQL restart.
+
 The profiler will also retrieve the query identifier for each instruction that
 contains an expression or optimizable statement.  Note that this requires
 pg_stat_statements, or another similar third-party extension), to be installed.

--- a/src/plpgsql_check.c
+++ b/src/plpgsql_check.c
@@ -278,6 +278,14 @@ _PG_init(void)
 	if (process_shared_preload_libraries_in_progress)
 	{
 
+		DefineCustomIntVariable("plpgsql_check.profiler_max_shared_chunks",
+						    "maximum numbers of statements chunks in shared memory",
+						    NULL,
+						    &plpgsql_check_profiler_max_shared_chunks,
+						    15000, 50, 100000,
+						    PGC_POSTMASTER, 0,
+						    NULL, NULL, NULL);
+
 		RequestAddinShmemSpace(plpgsql_check_shmem_size());
 
 #if PG_VERSION_NUM >= 90600

--- a/src/plpgsql_check.h
+++ b/src/plpgsql_check.h
@@ -299,6 +299,7 @@ extern Oid plpgsql_check_parse_name_or_signature(char *name_or_signature);
  * functions from profiler.c
  */
 extern bool plpgsql_check_profiler;
+extern int plpgsql_check_profiler_max_shared_chunks;
 
 extern Size plpgsql_check_shmem_size(void);
 extern void plpgsql_check_profiler_init_hash_tables(void);

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -97,12 +97,6 @@ typedef struct profiler_shared_state
 } profiler_shared_state;
 
 /*
- * should be enough for project of 300K PLpgSQL rows.
- * It should to take about 18MB of shared memory.
- */
-#define		MAX_SHARED_CHUNKS		15000
-
-/*
  * It is used for fast mapping plpgsql stmt -> stmtid
  */
 
@@ -197,6 +191,11 @@ static MemoryContext profiler_mcxt = NULL;
 static MemoryContext profiler_queryid_mcxt = NULL;
 
 bool plpgsql_check_profiler = true;
+/*
+ * should be enough for project of 300K PLpgSQL rows.
+ * It should to take about 24.4MB of shared memory.
+ */
+int plpgsql_check_profiler_max_shared_chunks = 15000;
 
 PG_FUNCTION_INFO_V1(plpgsql_profiler_reset_all);
 PG_FUNCTION_INFO_V1(plpgsql_profiler_reset);
@@ -434,7 +433,7 @@ plpgsql_check_shmem_size(void)
 
 	num_bytes = MAXALIGN(sizeof(profiler_shared_state));
 	num_bytes = add_size(num_bytes,
-						 hash_estimate_size(MAX_SHARED_CHUNKS,
+						 hash_estimate_size(plpgsql_check_profiler_max_shared_chunks,
 											sizeof(profiler_stmt_chunk)));
 
 	return num_bytes;
@@ -485,8 +484,8 @@ plpgsql_check_profiler_shmem_startup(void)
 	info.entrysize = sizeof(profiler_stmt_chunk);
 
 	shared_profiler_chunks_HashTable = ShmemInitHash("plpgsql_check profiler chunks",
-													MAX_SHARED_CHUNKS,
-													MAX_SHARED_CHUNKS,
+													plpgsql_check_profiler_max_shared_chunks,
+													plpgsql_check_profiler_max_shared_chunks,
 													&info,
 													HASH_ELEM | HASH_BLOBS);
 


### PR DESCRIPTION
As seen in https://github.com/okbob/plpgsql_check/issues/81 this commit add a
new GUC to allow users to change the previously hardcoded MAX_SHARED_CHUNKS.

The GUC is defined as PGC_POSTMASTER, as it has to be set at start time, but is
only defined when plpgsql_check is loaded via shared_preload_libraries, as it
would otherwise prevent users from loading the extension interactively.

The default values of 15000 is kept, and value between 50 and 100000 are
allowed.