### PR TITLE
Add support of operators to plpgsql_show_dependency_tb()

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ You can use pragma `table` and create ephemeral table:
 
 # Dependency list
 
-A function <i>plpgsql_show_dependency_tb</i> can show all functions and relations used
+A function <i>plpgsql_show_dependency_tb</i> can show all functions, operators and relations used
 inside processed function:
 
     postgres=# select * from plpgsql_show_dependency_tb('testfunc(int,float)');
@@ -420,6 +420,7 @@ inside processed function:
     ╞══════════╪═══════╪════════╪═════════╪════════════════════════════╡
     │ FUNCTION │ 36008 │ public │ myfunc1 │ (integer,double precision) │
     │ FUNCTION │ 35999 │ public │ myfunc2 │ (integer,double precision) │
+    │ OPERATOR │ 36007 │ public │ **      │ (integer,integer)          │
     │ RELATION │ 36005 │ public │ myview  │                            │
     │ RELATION │ 36002 │ public │ mytable │                            │
     └──────────┴───────┴────────┴─────────┴────────────────────────────┘

--- a/expected/plpgsql_check_active.out
+++ b/expected/plpgsql_check_active.out
@@ -3290,6 +3290,8 @@ create function myfunc1(a int, b float) returns integer as $$ begin end $$ langu
 create function myfunc2(a int, b float) returns integer as $$ begin end $$ language plpgsql;
 create function myfunc3(a int, b float) returns integer as $$ begin end $$ language plpgsql;
 create function myfunc4(a int, b float) returns integer as $$ begin end $$ language plpgsql;
+create function opfunc1(a int, b float) returns integer as $$ begin end $$ language plpgsql;
+create operator *** (procedure = opfunc1, leftarg = int, rightarg = float);
 create table mytable(a int);
 create table myview as select * from mytable;
 create function testfunc(a int, b float)
@@ -3297,7 +3299,7 @@ returns void as $$
 declare x integer;
 begin
   raise notice '%', myfunc1(a, b);
-  x := myfunc2(a, b);
+  x := myfunc2(a, b) operator(public.***) 1;
   perform myfunc3(m.a, b) from myview m;
   insert into mytable select myfunc4(a, b);
 end;
@@ -3315,9 +3317,10 @@ select type, schema, name, params from plpgsql_show_dependency_tb('testfunc(int,
  FUNCTION | public | myfunc2 | (integer,double precision)
  FUNCTION | public | myfunc3 | (integer,double precision)
  FUNCTION | public | myfunc4 | (integer,double precision)
+ OPERATOR | public | ***     | (integer,double precision)
  RELATION | public | mytable | 
  RELATION | public | myview  | 
-(6 rows)
+(7 rows)
 
 drop function testfunc(int, float);
 drop function myfunc1(int, float);

--- a/sql/plpgsql_check_active.sql
+++ b/sql/plpgsql_check_active.sql
@@ -2392,6 +2392,9 @@ create function myfunc2(a int, b float) returns integer as $$ begin end $$ langu
 create function myfunc3(a int, b float) returns integer as $$ begin end $$ language plpgsql;
 create function myfunc4(a int, b float) returns integer as $$ begin end $$ language plpgsql;
 
+create function opfunc1(a int, b float) returns integer as $$ begin end $$ language plpgsql;
+create operator *** (procedure = opfunc1, leftarg = int, rightarg = float);
+
 create table mytable(a int);
 create table myview as select * from mytable;
 
@@ -2400,7 +2403,7 @@ returns void as $$
 declare x integer;
 begin
   raise notice '%', myfunc1(a, b);
-  x := myfunc2(a, b);
+  x := myfunc2(a, b) operator(public.***) 1;
   perform myfunc3(m.a, b) from myview m;
   insert into mytable select myfunc4(a, b);
 end;

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -23,6 +23,7 @@
 #include "catalog/pg_extension.h"
 #include "catalog/indexing.h"
 #include "catalog/pg_language.h"
+#include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/extension.h"
@@ -341,3 +342,22 @@ plpgsql_check_is_plpgsql_function(Oid foid)
 	return result;
 }
 
+/*
+ * plpgsql_check_get_op_namespace
+ *	  returns the name space of the operator with the given opno
+ */
+Oid
+plpgsql_check_get_op_namespace(Oid opno)
+{
+	HeapTuple	tp;
+
+	tp = SearchSysCache1(OPEROID, ObjectIdGetDatum(opno));
+	if (HeapTupleIsValid(tp))
+	{
+		Form_pg_operator optup = (Form_pg_operator) GETSTRUCT(tp);
+		ReleaseSysCache(tp);
+		return optup->oprnamespace;
+	}
+	else
+		return InvalidOid;
+}

--- a/src/plpgsql_check.h
+++ b/src/plpgsql_check.h
@@ -203,6 +203,7 @@ extern void plpgsql_check_precheck_conditions(plpgsql_check_info *cinfo);
 extern char *plpgsql_check_get_src(HeapTuple procTuple);
 extern Oid plpgsql_check_pragma_func_oid(void);
 extern bool plpgsql_check_is_plpgsql_function(Oid foid);
+extern Oid plpgsql_check_get_op_namespace(Oid opno);
 
 /*
  * functions from tablefunc.c


### PR DESCRIPTION
Operators are especially tricky to find by just searching the code since
it is common for many operators to share the same name, so the ability
to find all dependencies on custom operators is a useful feature.