### PR TITLE
Properly ignore syntax errors from placeholders

### DIFF
--- a/expected/plpgsql_check_active.out
+++ b/expected/plpgsql_check_active.out
@@ -8187,3 +8187,15 @@ select lineno, exec_stmts, exec_stmts_err, source from plpgsql_profiler_function
 drop function test_function(int);
 drop function test_function1(int);
 set plpgsql_check.profiler to off;
+-- ignores syntax errors when literals placehodlers are used
+create function test_function()
+returns void as $$
+begin
+    execute format('do %L', 'begin end');
+end
+$$ language plpgsql;
+select * from plpgsql_check_function('test_function');
+ plpgsql_check_function 
+------------------------
+(0 rows)
+

--- a/expected/plpgsql_check_active_1.out
+++ b/expected/plpgsql_check_active_1.out
@@ -8206,3 +8206,15 @@ select lineno, exec_stmts, exec_stmts_err, source from plpgsql_profiler_function
 drop function test_function(int);
 drop function test_function1(int);
 set plpgsql_check.profiler to off;
+-- ignores syntax errors when literals placehodlers are used
+create function test_function()
+returns void as $$
+begin
+    execute format('do %L', 'begin end');
+end
+$$ language plpgsql;
+select * from plpgsql_check_function('test_function');
+ plpgsql_check_function 
+------------------------
+(0 rows)
+

--- a/expected/plpgsql_check_active_2.out
+++ b/expected/plpgsql_check_active_2.out
@@ -8186,3 +8186,15 @@ select lineno, exec_stmts, exec_stmts_err, source from plpgsql_profiler_function
 drop function test_function(int);
 drop function test_function1(int);
 set plpgsql_check.profiler to off;
+-- ignores syntax errors when literals placehodlers are used
+create function test_function()
+returns void as $$
+begin
+    execute format('do %L', 'begin end');
+end
+$$ language plpgsql;
+select * from plpgsql_check_function('test_function');
+ plpgsql_check_function 
+------------------------
+(0 rows)
+

--- a/expected/plpgsql_check_active_3.out
+++ b/expected/plpgsql_check_active_3.out
@@ -8186,3 +8186,15 @@ select lineno, exec_stmts, exec_stmts_err, source from plpgsql_profiler_function
 drop function test_function(int);
 drop function test_function1(int);
 set plpgsql_check.profiler to off;
+-- ignores syntax errors when literals placehodlers are used
+create function test_function()
+returns void as $$
+begin
+    execute format('do %L', 'begin end');
+end
+$$ language plpgsql;
+select * from plpgsql_check_function('test_function');
+ plpgsql_check_function 
+------------------------
+(0 rows)
+

--- a/sql/plpgsql_check_active.sql
+++ b/sql/plpgsql_check_active.sql
@@ -4748,3 +4748,12 @@ drop function test_function1(int);
 
 set plpgsql_check.profiler to off;
 
+-- ignores syntax errors when literals placehodlers are used
+create function test_function()
+returns void as $$
+begin
+    execute format('do %L', 'begin end');
+end
+$$ language plpgsql;
+
+select * from plpgsql_check_function('test_function');

--- a/src/stmtwalk.c
+++ b/src/stmtwalk.c
@@ -1900,7 +1900,7 @@ check_dynamic_sql(PLpgSQL_checkstate *cstate,
 							 * so most safe value is NULL instead.
 							 */
 							appendStringInfo(&sinfo, " null ");
-							found_literal_placeholder = false;
+							found_literal_placeholder = true;
 							expr_is_const = false;
 						}
 						else


### PR DESCRIPTION
The old code tried to skip parsing when there are any string literals in
the dynamic SQL but due to a suspected typo (false instead of true) it
did not actually do so.

An example where literal placeholders can cause syntax errors in valid
code is `format('SELECT json %L', v)` which `check_dynamic_sql()` transforms
into `SELECT json null` which is invalid SQL in PostgreSQL <=13.

I added the new regression test at the end of the file since I was unsure of where it should be placed.