### PR TITLE
Fix compatibility with pg15.

### DIFF
--- a/src/plpgsql_check.h
+++ b/src/plpgsql_check.h
@@ -15,6 +15,10 @@ typedef uint32 pc_queryid;
 #define NOQUERYID	(0)
 #endif
 
+#if PG_VERSION_NUM < 150000
+#define parse_analyze_fixedparams	parse_analyze
+#endif
+
 enum
 {
 	PLPGSQL_CHECK_ERROR,

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -2160,7 +2160,7 @@ profiler_get_dyn_queryid(PLpgSQL_execstate *estate, PLpgSQL_expr *expr, query_pa
 		snapshot_set = true;
 	}
 
-	query = parse_analyze(parsetree, query_string, paramtypes, nparams, NULL);
+	query = parse_analyze_fixedparams(parsetree, query_string, paramtypes, nparams, NULL);
 
 	if (snapshot_set)
 		PopActiveSnapshot();


### PR DESCRIPTION
Upstream commit 791b1b71da35d9d4264f72a87e4078b85a2fcfb4 renamed
parse_analyze() to parse_analyze_fixedparams(), so adopt that new name and add
a macro for backward compatibility.