### PR TITLE
Detect return properly even when record check fails

### DIFF
--- a/expected/plpgsql_check_active.out
+++ b/expected/plpgsql_check_active.out
@@ -3410,6 +3410,14 @@ begin
   return row(10,20,30);
 end;
 $$ language plpgsql;
+create type record03 as (a int, b int);
+create or replace function rrecord03()
+returns record03 as $$
+declare r record := row(1);
+begin
+  return r;
+end;
+$$ language plpgsql;
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
  plpgsql_check_function 
@@ -3421,8 +3429,18 @@ select * from plpgsql_check_function('rrecord02');
 ------------------------
 (0 rows)
 
+-- should detect different return but still detect return
+select * from plpgsql_check_function('rrecord03', fatal_errors => false);
+                              plpgsql_check_function                              
+----------------------------------------------------------------------------------
+ error:42804:4:RETURN:returned record type does not match expected record type
+ Detail: Number of returned columns (1) does not match expected column count (2).
+(2 rows)
+
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord03();
+drop type record03;
 create or replace function bugfunc01()
 returns void as $$
 declare

--- a/expected/plpgsql_check_active_1.out
+++ b/expected/plpgsql_check_active_1.out
@@ -3419,6 +3419,14 @@ begin
   return row(10,20,30);
 end;
 $$ language plpgsql;
+create type record03 as (a int, b int);
+create or replace function rrecord03()
+returns record03 as $$
+declare r record := row(1);
+begin
+  return r;
+end;
+$$ language plpgsql;
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
  plpgsql_check_function 
@@ -3430,8 +3438,18 @@ select * from plpgsql_check_function('rrecord02');
 ------------------------
 (0 rows)
 
+-- should detect different return but still detect return
+select * from plpgsql_check_function('rrecord03', fatal_errors => false);
+                              plpgsql_check_function                              
+----------------------------------------------------------------------------------
+ error:42804:4:RETURN:returned record type does not match expected record type
+ Detail: Number of returned columns (1) does not match expected column count (2).
+(2 rows)
+
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord03();
+drop type record03;
 create or replace function bugfunc01()
 returns void as $$
 declare

--- a/expected/plpgsql_check_active_2.out
+++ b/expected/plpgsql_check_active_2.out
@@ -3410,6 +3410,14 @@ begin
   return row(10,20,30);
 end;
 $$ language plpgsql;
+create type record03 as (a int, b int);
+create or replace function rrecord03()
+returns record03 as $$
+declare r record := row(1);
+begin
+  return r;
+end;
+$$ language plpgsql;
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
  plpgsql_check_function 
@@ -3421,8 +3429,18 @@ select * from plpgsql_check_function('rrecord02');
 ------------------------
 (0 rows)
 
+-- should detect different return but still detect return
+select * from plpgsql_check_function('rrecord03', fatal_errors => false);
+                              plpgsql_check_function                              
+----------------------------------------------------------------------------------
+ error:42804:4:RETURN:returned record type does not match expected record type
+ Detail: Number of returned columns (1) does not match expected column count (2).
+(2 rows)
+
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord03();
+drop type record03;
 create or replace function bugfunc01()
 returns void as $$
 declare

--- a/expected/plpgsql_check_active_3.out
+++ b/expected/plpgsql_check_active_3.out
@@ -3410,6 +3410,14 @@ begin
   return row(10,20,30);
 end;
 $$ language plpgsql;
+create type record03 as (a int, b int);
+create or replace function rrecord03()
+returns record03 as $$
+declare r record := row(1);
+begin
+  return r;
+end;
+$$ language plpgsql;
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
  plpgsql_check_function 
@@ -3421,8 +3429,18 @@ select * from plpgsql_check_function('rrecord02');
 ------------------------
 (0 rows)
 
+-- should detect different return but still detect return
+select * from plpgsql_check_function('rrecord03', fatal_errors => false);
+                              plpgsql_check_function                              
+----------------------------------------------------------------------------------
+ error:42804:4:RETURN:returned record type does not match expected record type
+ Detail: Number of returned columns (1) does not match expected column count (2).
+(2 rows)
+
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord03();
+drop type record03;
 create or replace function bugfunc01()
 returns void as $$
 declare

--- a/sql/plpgsql_check_active.sql
+++ b/sql/plpgsql_check_active.sql
@@ -2492,12 +2492,26 @@ begin
 end;
 $$ language plpgsql;
 
+create type record03 as (a int, b int);
+
+create or replace function rrecord03()
+returns record03 as $$
+declare r record := row(1);
+begin
+  return r;
+end;
+$$ language plpgsql;
+
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
 select * from plpgsql_check_function('rrecord02');
+-- should detect different return but still detect return
+select * from plpgsql_check_function('rrecord03', fatal_errors => false);
 
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord03();
+drop type record03;
 
 create or replace function bugfunc01()
 returns void as $$

--- a/src/stmtwalk.c
+++ b/src/stmtwalk.c
@@ -829,6 +829,8 @@ plpgsql_check_stmt(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt, int *closing,
 				{
 					PLpgSQL_stmt_return *stmt_rt = (PLpgSQL_stmt_return *) stmt;
 
+					*closing = PLPGSQL_CHECK_CLOSED;
+
 					if (stmt_rt->retvarno >= 0)
 					{
 						PLpgSQL_datum *retvar = cstate->estate->datums[stmt_rt->retvarno];
@@ -888,8 +890,6 @@ plpgsql_check_stmt(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt, int *closing,
 								;		/* nope */
 						}
 					}
-
-					*closing = PLPGSQL_CHECK_CLOSED;
 
 					if (stmt_rt->expr)
 						plpgsql_check_returned_expr(cstate, stmt_rt->expr, true);


### PR DESCRIPTION
By recording that we found a return before we check the the record
type we make sure to not give false "reached end of function without
RETURN" errors if the record type check errors out.

Here is an example of the issue:

```
create type record03 as (a int, b int);

create or replace function rrecord03()
returns record03 as $$
declare r record := row(1);
begin
  return r;
end;
$$ language plpgsql;
```

```
select * from plpgsql_check_function('rrecord03', fatal_errors => false);
                              plpgsql_check_function                              
----------------------------------------------------------------------------------
 error:42804:4:RETURN:returned record type does not match expected record type
 Detail: Number of returned columns (1) does not match expected column count (2).
 error:2F005:control reached end of function without RETURN
(3 rows)
```

And a question which this made me think of is that when there is a type mismatch for not records  (e.g. returning an `int` when the return type is `timestamptz`) that is just a warning while this is an error which feels inconsistent.