### PR TITLE
Fix false positive for record return type

### DIFF
--- a/expected/plpgsql_check_active.out
+++ b/expected/plpgsql_check_active.out
@@ -3410,6 +3410,14 @@ begin
   return row(10,20,30);
 end;
 $$ language plpgsql;
+create type record04 as (a int, b int);
+create or replace function rrecord04()
+returns record as $$
+declare r record04 := row(10,20);
+begin
+  return r;
+end;
+$$ language plpgsql;
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
  plpgsql_check_function 
@@ -3421,8 +3429,15 @@ select * from plpgsql_check_function('rrecord02');
 ------------------------
 (0 rows)
 
+select * from plpgsql_check_function('rrecord04');
+ plpgsql_check_function 
+------------------------
+(0 rows)
+
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord04();
+drop type record04;
 create or replace function bugfunc01()
 returns void as $$
 declare

--- a/expected/plpgsql_check_active_1.out
+++ b/expected/plpgsql_check_active_1.out
@@ -3419,6 +3419,14 @@ begin
   return row(10,20,30);
 end;
 $$ language plpgsql;
+create type record04 as (a int, b int);
+create or replace function rrecord04()
+returns record as $$
+declare r record04 := row(10,20);
+begin
+  return r;
+end;
+$$ language plpgsql;
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
  plpgsql_check_function 
@@ -3430,8 +3438,15 @@ select * from plpgsql_check_function('rrecord02');
 ------------------------
 (0 rows)
 
+select * from plpgsql_check_function('rrecord04');
+ plpgsql_check_function 
+------------------------
+(0 rows)
+
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord04();
+drop type record04;
 create or replace function bugfunc01()
 returns void as $$
 declare

--- a/expected/plpgsql_check_active_2.out
+++ b/expected/plpgsql_check_active_2.out
@@ -3410,6 +3410,14 @@ begin
   return row(10,20,30);
 end;
 $$ language plpgsql;
+create type record04 as (a int, b int);
+create or replace function rrecord04()
+returns record as $$
+declare r record04 := row(10,20);
+begin
+  return r;
+end;
+$$ language plpgsql;
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
  plpgsql_check_function 
@@ -3421,8 +3429,15 @@ select * from plpgsql_check_function('rrecord02');
 ------------------------
 (0 rows)
 
+select * from plpgsql_check_function('rrecord04');
+ plpgsql_check_function 
+------------------------
+(0 rows)
+
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord04();
+drop type record04;
 create or replace function bugfunc01()
 returns void as $$
 declare

--- a/expected/plpgsql_check_active_3.out
+++ b/expected/plpgsql_check_active_3.out
@@ -3410,6 +3410,14 @@ begin
   return row(10,20,30);
 end;
 $$ language plpgsql;
+create type record04 as (a int, b int);
+create or replace function rrecord04()
+returns record as $$
+declare r record04 := row(10,20);
+begin
+  return r;
+end;
+$$ language plpgsql;
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
  plpgsql_check_function 
@@ -3421,8 +3429,15 @@ select * from plpgsql_check_function('rrecord02');
 ------------------------
 (0 rows)
 
+select * from plpgsql_check_function('rrecord04');
+ plpgsql_check_function 
+------------------------
+(0 rows)
+
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord04();
+drop type record04;
 create or replace function bugfunc01()
 returns void as $$
 declare

--- a/sql/plpgsql_check_active.sql
+++ b/sql/plpgsql_check_active.sql
@@ -2492,12 +2492,25 @@ begin
 end;
 $$ language plpgsql;
 
+create type record04 as (a int, b int);
+
+create or replace function rrecord04()
+returns record as $$
+declare r record04 := row(10,20);
+begin
+  return r;
+end;
+$$ language plpgsql;
+
 -- should not to raise false alarms
 select * from plpgsql_check_function('rrecord01');
 select * from plpgsql_check_function('rrecord02');
+select * from plpgsql_check_function('rrecord04');
 
 drop function rrecord01();
 drop function rrecord02();
+drop function rrecord04();
+drop type record04;
 
 create or replace function bugfunc01()
 returns void as $$

--- a/src/stmtwalk.c
+++ b/src/stmtwalk.c
@@ -855,13 +855,18 @@ plpgsql_check_stmt(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt, int *closing,
 									if (recvar_tupdesc(rec) && estate->rsi && IsA(estate->rsi, ReturnSetInfo))
 									{
 										TupleDesc	rettupdesc = estate->rsi->expectedDesc;
-										TupleConversionMap *tupmap ;
 
-										tupmap = convert_tuples_by_position(recvar_tupdesc(rec), rettupdesc,
-											 gettext_noop("returned record type does not match expected record type"));
+										// There are no meaningsful checks if the return type is the anonymous record
+										if (rettupdesc->tdtypeid != RECORDOID)
+										{
+											TupleConversionMap *tupmap;
 
-										if (tupmap)
-											free_conversion_map(tupmap);
+											tupmap = convert_tuples_by_position(recvar_tupdesc(rec), rettupdesc,
+												 gettext_noop("returned record type does not match expected record type"));
+
+											if (tupmap)
+												free_conversion_map(tupmap);
+										}
 									}
 								}
 								break;
@@ -873,13 +878,18 @@ plpgsql_check_stmt(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt, int *closing,
 									if (row->rowtupdesc && estate->rsi && IsA(estate->rsi, ReturnSetInfo))
 									{
 										TupleDesc	rettupdesc = estate->rsi->expectedDesc;
-										TupleConversionMap *tupmap ;
 
-										tupmap = convert_tuples_by_position(row->rowtupdesc, rettupdesc,
-											 gettext_noop("returned record type does not match expected record type"));
+										// There are no meaningsful checks if the return type is the anonymous record
+										if (rettupdesc->tdtypeid != RECORDOID)
+										{
+											TupleConversionMap *tupmap;
 
-										if (tupmap)
-											free_conversion_map(tupmap);
+											tupmap = convert_tuples_by_position(row->rowtupdesc, rettupdesc,
+												 gettext_noop("returned record type does not match expected record type"));
+
+											if (tupmap)
+												free_conversion_map(tupmap);
+										}
 									}
 								}
 								break;


### PR DESCRIPTION
PostgreSQL for some reason instantiates the anonymous record return
type for functions and this causes the record structure comparison to
fail in some instances.

And since it does not really make sense to compare the structure of
a returned tuple with a fully anonymous return type (they should
always match) we may as well skip the check for this case instead of
trying to fix it.

@okbob I am not entirely sure actually why PostgreSQL instantiates the anonymous return type and also does so in a weird way. As far as I can tell PostgreSQL instantiates it as `ROW(record)`. So take this patch with a grain of salt since I am clearly missing something in my understanding of PG internals.

To reproduce this error:

```sql
create type record04 as (a int, b int);

create or replace function rrecord04()
returns record as $$
declare r record04 := row(10,20);
begin
  return r;
end;
$$ language plpgsql;
```

```
select * from plpgsql_check_function('rrecord04');
                             plpgsql_check_function                             
--------------------------------------------------------------------------------
 error:42804:4:RETURN:returned record type does not match expected record type
 Detail: Returned type integer does not match expected type record in column 1.
(2 rows)
```