### PR TITLE
Add compatibility with pg16 new "USER SET parameter values" infrastru…

### DIFF
--- a/src/check_function.c
+++ b/src/check_function.c
@@ -1318,6 +1318,9 @@ load_configuration(HeapTuple procTuple, bool *reload_config)
 			new_nest_level = NewGUCNestLevel();
 			*reload_config = true;
 			ProcessGUCArray(set_items,
+#if PG_VERSION_NUM >= 160000
+							NULL,
+#endif
 							(superuser() ? PGC_SUSET : PGC_USERSET),
 							PGC_S_SESSION,
 							GUC_ACTION_SAVE);


### PR DESCRIPTION
…cture.

Infrastructure added in upstream commit 096dd80f3cc, which changed the ProcessGUCArray API.

Fixes #134.


Note: IIUC, as for upstream commit in `fmgr_security_definer()` passing a NULL usersetArray should be ok.