### PR TITLE
Problem: impossible to supply custom PG_CONFIG to PGXS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 else
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 endif


### PR DESCRIPTION
This somewhat limits the ability to configure this extension with separately installed Postgres without manipulating PATH.

Solution: use conditional PG_CONFIG assignment

If PG_CONFIG is supplied externally, it'll be used instead of the one hardcoded.

---

Example of such use: https://github.com/pgvector/pgvector/blob/master/Makefile#L46