### PR TITLE
fix forgotten version bump in PG_MODULE_MAGIC_EXT to 2.9.2

### DIFF
--- a/src/plpgsql_check.c
+++ b/src/plpgsql_check.c
@@ -46,7 +46,7 @@
 
 PG_MODULE_MAGIC_EXT(
 					.name = "plpgsql_check",
-					.version = "2.9.1"
+					.version = "2.9.2"
 );
 
 #else


### PR DESCRIPTION
In v2.9.2 the version string inside `PG_MODULE_MAGIC_EXT` was left at the previous value while the rest of the tree was bumped. This aligns it with the release tag.