### PR TITLE
Fix PG14 LWLock tranche registration in _PG_init

### DIFF
--- a/src/plpgsql_check.c
+++ b/src/plpgsql_check.c
@@ -484,8 +484,8 @@ _PG_init(void)
 		 */
 		RequestAddinShmemSpace(plpgsql_check_shmem_size());
 
-		RequestNamedLWLockTranche("plpgsql_check profiler", 1);
-		RequestNamedLWLockTranche("plpgsql_check fstats", 1);
+		RequestNamedLWLockTranche("plpgsql_check profiler funcs stats", 1);
+		RequestNamedLWLockTranche("plpgsql_check profiler func stmts stats", 1);
 
 #endif
 


### PR DESCRIPTION
  Fixes #214
  
  Updates `RequestNamedLWLockTranche` inside `_PG_init()` (`#if PG_VERSION_NUM < 150000`) to match the new tranche names used by `plpgsql_check_profiler_shmem_startup()`.