### PR TITLE
`plpgsql_make_pragma`: support for CREATE TABLE statement based forms of temporary tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,9 +517,9 @@ You can use pragma `table` and create ephemeral table:
        PERFORM plpgsql_check_pragma('table: [pg_temp].zzz(like schemaname.table1 including all)');
        ...
 
-For temporary tables created by the `CREATE TEMP TABLE AS` statement, the table pragmas
-can be generated automatically by the function `plpgsql_make_pragma`
-(see the section "Table pragmas generator").
+For temporary tables created inside the function's body, the table pragmas can be
+generated automatically by the function `plpgsql_make_pragma` (see the section
+"Table pragmas generator").
 
 
 # Dependency list
@@ -898,7 +898,8 @@ Shorter syntax for pragma is supported too:
   
 * `type:varname typename` or `type:varname (fieldname type, ...)` - set type to variable of record type
 
-* `table: name (column_name type, ...)` or `table: name (like tablename)` - create ephemeral temporary table (if you want to specify schema, then only `pg_temp` schema is allowed.
+* `table: name (column_name type, ...)` or `table: name (like tablename)` - create ephemeral temporary table (if you want to specify schema, then only `pg_temp` schema is allowed).
+  The column list supports only a column name and a type (with optional type modifiers and array dimensions) - column constraints (`PRIMARY KEY`, `NOT NULL`, `DEFAULT`, `CHECK`) and `COLLATE` clauses are not supported here.
 
 * `sequence: name` - create ephemeral temporary sequence
 
@@ -914,13 +915,22 @@ Pragmas `enable:tracer` and `disable:tracer`are active for Postgres 12 and highe
 
 <i>plpgsql_check</i> cannot verify queries over temporary tables that are created at runtime.
 The pragma `table` solves this issue, but the column list must be written (and maintained)
-manually there - it gets out of sync easily when the query is changed. For temporary tables
-created by the `CREATE TEMP TABLE AS` statement, these pragmas can be generated automatically
-by the function `plpgsql_make_pragma`. It scans the function's body, and for
-every `CREATE TEMP TABLE ... AS SELECT|VALUES|TABLE` statement it returns one table pragma
-string. The names and types of columns are derived from planning of the inner query. The query
-is planned, but never executed - the function has no side effects, it doesn't create any object
-in the system catalogue, and repeated calls return the same result.
+manually there - it gets out of sync easily when the definition is changed. These pragmas
+can be generated automatically by the function `plpgsql_make_pragma`. It scans the
+function's body, and for every statement there that creates a temporary table it returns
+one table pragma string.
+
+For `CREATE TEMP TABLE ... AS SELECT|VALUES|TABLE` statements the names and types of
+columns are derived from planning of the inner query (the query is never executed). For
+`CREATE TEMP TABLE` statements (the column definition list, the `LIKE` clause, the
+`OF type_name` clause, inheritance and partitioning) the statement is executed inside an
+always rolled back subtransaction, and the pragma is derived from the structure of the
+really created table - so serial or identity columns, inherited or LIKE-copied columns
+are expanded by PostgreSQL itself. Column constraints (`PRIMARY KEY`, `NOT NULL`,
+`DEFAULT`, `CHECK`) don't block the generation, but they are not carried into the
+generated pragma - the pragma holds only column names and types, which is enough for
+the static checks. In both cases no object survives the call, and repeated calls
+return the same result.
 
     create table gtp_src(a int, b text);
 
@@ -1005,12 +1015,37 @@ The statements are processed in the order of appearance in the function's body (
 blocks, loops, IF branches and exception handlers are scanned too), and the pragmas are
 returned in the same order without deduplication. Explicitly written table pragmas inside
 the function's body are respected, so a temporary table created by dynamic SQL can be
-declared manually, and the following `CREATE TEMP TABLE AS` statements can reference it.
+declared manually, and the following statements can reference it.
 
-Only statically written `CREATE TEMP TABLE ... AS SELECT|VALUES|TABLE` commands are
-processed. Other forms of temporary tables - the column definition list, the `LIKE`
-clause and the `OF type_name` clause - and dynamic SQL are ignored (the pragma cannot
-be derived from them). Not temporary tables and materialized views are ignored too.
+The `CREATE TEMP TABLE` statement based forms are supported in all variants - with
+storage parameters, access method, `ON COMMIT` or `IF NOT EXISTS` clauses, or with the
+`pg_temp` schema qualification used without the `TEMP` keyword:
+
+    create or replace function gtp_f20()
+    returns void as $$
+    begin
+      create temp table gtp_x (id serial, v varchar(10));
+      create temp table gtp_y (like gtp_x including all);
+      insert into gtp_y(v) values ('hello');
+    end;
+    $$ language plpgsql;
+
+    postgres=# select * from plpgsql_make_pragma('gtp_f20()');
+                    plpgsql_make_pragma                
+    ---------------------------------------------------
+     table: gtp_x(id integer, v character varying(10))
+     table: gtp_y(id integer, v character varying(10))
+    (2 rows)
+
+Only statically written commands are processed - dynamic SQL (`EXECUTE`), not temporary
+tables and materialized views are ignored.
+
+A name collision (usually the pattern `CREATE`, `DROP`, `CREATE` with the same name -
+DROP statements are not executed by static scanning) is not an error. A warning is
+raised, pragmas are returned for both definitions, and the following statements of the
+function's body see the last definition like in runtime. `CREATE TEMP TABLE IF NOT EXISTS`
+over an existing table returns the structure of the existing table (the existing table
+wins like in runtime).
 
 The function raises an error when:
 
@@ -1025,7 +1060,11 @@ The function raises an error when:
   forms too),
 
 * more column names are explicitly specified than the query returns - the error
-  `too many column names were specified`.
+  `too many column names were specified`,
+
+* the execution of a `CREATE TEMP TABLE` statement fails - e.g. a temporary partition
+  of a persistent table, a foreign key from a temporary table to a persistent table, or
+  the `LIKE` clause over a missing table. The error is the same like in runtime.
 
 When the option `fatal_errors` is false, then failed statements are skipped (with a
 warning), and the scanning continues.

--- a/expected/plpgsql_pragma_generator.out
+++ b/expected/plpgsql_pragma_generator.out
@@ -283,23 +283,26 @@ select * from plpgsql_make_pragma('gtp_f13()');
 (6 rows)
 
 drop function gtp_f13();
--- positional processing - same table name twice (no deduplication)
+-- positional processing - same table name twice (no deduplication),
+-- the following statements see the last definition
 create function gtp_f14()
 returns void as $$
 begin
   create temp table gtp_dup as select 1 as x;
   drop table gtp_dup;
   create temp table gtp_dup as select 'a'::text as y;
+  create temp table gtp_dup2 as select * from gtp_dup;
 end;
 $$ language plpgsql;
 select * from plpgsql_make_pragma('gtp_f14()');
-WARNING:  Pragma "table" on line 5 is not processed.
-DETAIL:  relation "gtp_dup" already exists
+WARNING:  relation "gtp_dup" already exists
+DETAIL:  The temporary table is replaced by the new definition.
     plpgsql_make_pragma    
 ---------------------------
  table: gtp_dup(x integer)
  table: gtp_dup(y text)
-(2 rows)
+ table: gtp_dup2(y text)
+(3 rows)
 
 drop function gtp_f14();
 -- one temporary table references another one
@@ -358,20 +361,18 @@ select * from plpgsql_make_pragma('gtp_f17()');
 (2 rows)
 
 drop function gtp_f17();
--- these forms are ignored - column definition list, LIKE clause,
--- OF type clause, dynamic SQL, not temporary tables and materialized
--- views
+-- these forms are ignored - dynamic SQL, not temporary tables and
+-- materialized views
 create function gtp_f18()
 returns void as $$
 begin
-  create temp table gtp_s1(id int, name text);
-  create temp table gtp_s2(like gtp_src);
-  create temp table gtp_s3 of gtp_ct;
   execute 'create temp table gtp_s4 as select 1 as x';
   create table gtp_s5 as select a from gtp_src;
   create unlogged table gtp_s6 as select a from gtp_src;
+  create table gtp_s8 (id int);
+  create unlogged table gtp_s9 (id int);
   create materialized view gtp_s7 as select a from gtp_src;
-  drop table gtp_s1, gtp_s2, gtp_s3, gtp_s4, gtp_s5, gtp_s6;
+  drop table gtp_s4, gtp_s5, gtp_s6, gtp_s8, gtp_s9;
   drop materialized view gtp_s7;
 end;
 $$ language plpgsql;
@@ -517,6 +518,221 @@ select * from plpgsql_make_pragma('gtp_f23()');
 (1 row)
 
 drop function gtp_f23();
+-- CREATE TABLE statement based forms. The temporary table is created
+-- inside the check's subtransaction (and removed by its rollback), and
+-- the pragma is derived from the structure of really created table.
+-- Column definition list form - typmods, quoting, serial, identity and
+-- generated columns, constraints, collation (not carried to pragma),
+-- zero columns
+create function gtp_cs1()
+returns void as $$
+begin
+  create temp table gtp_cl1 (id int, name text);
+  create temp table gtp_cl2 (v varchar(10), n numeric(12,2), t text collate "C");
+  create temp table "GtpQ" ("select" int, normal text);
+  create temp table gtp_cl3 (id serial, iid int generated always as identity,
+                             g int generated always as (id + 1) stored);
+  create temp table gtp_cl4 (id int primary key, v text not null default 'x',
+                             check (id > 0));
+  create temp table gtp_cl5 ();
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_cs1()');
+                       plpgsql_make_pragma                        
+------------------------------------------------------------------
+ table: gtp_cl1(id integer, name text)
+ table: gtp_cl2(v character varying(10), n numeric(12,2), t text)
+ table: "GtpQ"("select" integer, normal text)
+ table: gtp_cl3(id integer, iid integer, g integer)
+ table: gtp_cl4(id integer, v text)
+ table: gtp_cl5()
+(6 rows)
+
+drop function gtp_cs1();
+-- LIKE clause and OF type clause
+create function gtp_cs2()
+returns void as $$
+begin
+  create temp table gtp_lk1 (like gtp_src);
+  create temp table gtp_lk2 (like gtp_src including all);
+  create temp table gtp_lk3 (id int, like gtp_src);
+  create temp table gtp_of1 of gtp_ct;
+  create temp table gtp_of2 of gtp_ct (x with options not null);
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_cs2()');
+              plpgsql_make_pragma              
+-----------------------------------------------
+ table: gtp_lk1(a integer, b text)
+ table: gtp_lk2(a integer, b text)
+ table: gtp_lk3(id integer, a integer, b text)
+ table: gtp_of1(x integer, y text)
+ table: gtp_of2(x integer, y text)
+(5 rows)
+
+drop function gtp_cs2();
+-- inheritance - from a persistent table and from a temporary table
+-- created earlier in same function
+create table gtp_parent(pid int, pval text);
+create function gtp_cs3()
+returns void as $$
+begin
+  create temp table gtp_inh1 () inherits (gtp_parent);
+  create temp table gtp_inh2 (own text) inherits (gtp_parent);
+  create temp table gtp_tp (a int, b text);
+  create temp table gtp_inh3 () inherits (gtp_tp);
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_cs3()');
+                plpgsql_make_pragma                
+---------------------------------------------------
+ table: gtp_inh1(pid integer, pval text)
+ table: gtp_inh2(pid integer, pval text, own text)
+ table: gtp_tp(a integer, b text)
+ table: gtp_inh3(a integer, b text)
+(4 rows)
+
+drop function gtp_cs3();
+drop table gtp_parent;
+-- partitioning - temporary parent and temporary partitions
+create function gtp_cs4()
+returns void as $$
+begin
+  create temp table gtp_pp (id int, v text) partition by range (id);
+  create temp table gtp_p1 partition of gtp_pp for values from (1) to (100);
+  create temp table gtp_p2 partition of gtp_pp default;
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_cs4()');
+        plpgsql_make_pragma        
+-----------------------------------
+ table: gtp_pp(id integer, v text)
+ table: gtp_p1(id integer, v text)
+ table: gtp_p2(id integer, v text)
+(3 rows)
+
+drop function gtp_cs4();
+-- storage options, access method, ON COMMIT variants, IF NOT EXISTS
+-- (the existing table wins - like runtime does), pg_temp qualification
+-- without TEMP keyword
+create function gtp_cs5()
+returns void as $$
+begin
+  create temp table gtp_o1 (a int) with (fillfactor = 70);
+  create temp table gtp_o2 (a int) using heap;
+  create temp table gtp_o3 (a int) on commit preserve rows;
+  create temp table gtp_o4 (a int) on commit delete rows;
+  create temp table gtp_o5 (a int) on commit drop;
+  create temp table if not exists gtp_o6 (a int);
+  create temp table if not exists gtp_o6 (b text);
+  create table pg_temp.gtp_o7 (a int);
+  create table pg_temp.gtp_o8 (like gtp_src);
+  create table pg_temp.gtp_o9 of gtp_ct;
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_cs5()');
+NOTICE:  relation "gtp_o6" already exists, skipping
+       plpgsql_make_pragma        
+----------------------------------
+ table: gtp_o1(a integer)
+ table: gtp_o2(a integer)
+ table: gtp_o3(a integer)
+ table: gtp_o4(a integer)
+ table: gtp_o5(a integer)
+ table: gtp_o6(a integer)
+ table: gtp_o6(a integer)
+ table: gtp_o7(a integer)
+ table: gtp_o8(a integer, b text)
+ table: gtp_o9(x integer, y text)
+(10 rows)
+
+drop function gtp_cs5();
+-- mixed CREATE TABLE AS and CREATE TABLE statements
+create function gtp_mx1()
+returns void as $$
+begin
+  create temp table gtp_mm1 as select a, b from gtp_src;
+  create temp table gtp_mm2 (id int, v text);
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_mx1()');
+        plpgsql_make_pragma         
+------------------------------------
+ table: gtp_mm1(a integer, b text)
+ table: gtp_mm2(id integer, v text)
+(2 rows)
+
+drop function gtp_mx1();
+-- the table created by CREATE TABLE statement is visible for the
+-- following CREATE TABLE AS statements (join, subquery)
+create function gtp_mx2()
+returns void as $$
+begin
+  create temp table gtp_mn1 (a int, b text);
+  create temp table gtp_mn2 as
+    select gtp_mn1.a, s.b from gtp_mn1 join gtp_src s on s.a = gtp_mn1.a
+    where gtp_mn1.a in (select a from gtp_mn1);
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_mx2()');
+        plpgsql_make_pragma        
+-----------------------------------
+ table: gtp_mn1(a integer, b text)
+ table: gtp_mn2(a integer, b text)
+(2 rows)
+
+drop function gtp_mx2();
+-- and the reverse order - the table created by CREATE TABLE AS
+-- statement is visible for the following CREATE TABLE statement
+create function gtp_mx3()
+returns void as $$
+begin
+  create temp table gtp_mo1 as select a, b from gtp_src;
+  create temp table gtp_mo2 (like gtp_mo1 including all);
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_mx3()');
+        plpgsql_make_pragma        
+-----------------------------------
+ table: gtp_mo1(a integer, b text)
+ table: gtp_mo2(a integer, b text)
+(2 rows)
+
+drop function gtp_mx3();
+-- generator of CREATE TABLE statement based pragmas is idempotent too
+create function gtp_cs6()
+returns void as $$
+begin
+  create temp table gtp_ii (id int, v text);
+  insert into gtp_ii values (1, 'x');
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_cs6()');
+        plpgsql_make_pragma        
+-----------------------------------
+ table: gtp_ii(id integer, v text)
+(1 row)
+
+select * from plpgsql_make_pragma('gtp_cs6()');
+        plpgsql_make_pragma        
+-----------------------------------
+ table: gtp_ii(id integer, v text)
+(1 row)
+
+select count(*) from pg_class where relname in ('gtp_ii');
+ count 
+-------
+     0
+(1 row)
+
+-- generated pragma is usable by "pragmas" option
+select * from plpgsql_check_function('gtp_cs6()',
+          pragmas => array(select plpgsql_make_pragma('gtp_cs6()')));
+ plpgsql_check_function 
+------------------------
+(0 rows)
+
+drop function gtp_cs6();
 -- error cases
 create function gtp_err1()
 returns void as $$
@@ -597,8 +813,9 @@ end;
 $$;
 NOTICE:  sqlstate: 42P16, message: cannot create temporary relation in non-temporary schema
 drop function gtp_err3();
--- same check is done for ignored forms too (column definition list,
--- LIKE clause, OF type clause), and it respects fatal_errors option
+-- the check of target schema is done before execution for CREATE TABLE
+-- statement forms too (column definition list, LIKE clause, OF type
+-- clause), and it respects fatal_errors option
 create function gtp_err4()
 returns void as $$
 begin
@@ -649,6 +866,132 @@ end;
 $$;
 NOTICE:  sqlstate: 42601, message: too many column names were specified
 drop function gtp_err5();
+-- duplicate table name (usually the pattern CREATE, DROP, CREATE with
+-- same name) is reported as warning only - DROP statements are not
+-- executed by static scanning, so this is not a real error. Pragmas
+-- are returned for both definitions, and the following statements see
+-- the last definition.
+create function gtp_err6()
+returns void as $$
+begin
+  create temp table gtp_dd (x int);
+  drop table gtp_dd;
+  create temp table gtp_dd (y text);
+  create temp table gtp_dd2 (z int);
+  create temp table gtp_dd3 as select * from gtp_dd;
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_err6()');
+WARNING:  relation "gtp_dd" already exists
+DETAIL:  The temporary table is replaced by the new definition.
+    plpgsql_make_pragma    
+---------------------------
+ table: gtp_dd(x integer)
+ table: gtp_dd(y text)
+ table: gtp_dd2(z integer)
+ table: gtp_dd3(y text)
+(4 rows)
+
+drop function gtp_err6();
+-- mixed collisions - CREATE TABLE statement redefined by CREATE TABLE
+-- AS statement and vice versa
+create function gtp_err9()
+returns void as $$
+begin
+  create temp table gtp_md (a int);
+  drop table gtp_md;
+  create temp table gtp_md as select 'x'::text as t;
+  create temp table gtp_md2 as select 1 as b;
+  drop table gtp_md2;
+  create temp table gtp_md2 (c date);
+  create temp table gtp_md3 as select * from gtp_md, gtp_md2;
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_err9()');
+WARNING:  relation "gtp_md" already exists
+DETAIL:  The temporary table is replaced by the new definition.
+WARNING:  relation "gtp_md2" already exists
+DETAIL:  The temporary table is replaced by the new definition.
+      plpgsql_make_pragma       
+--------------------------------
+ table: gtp_md(a integer)
+ table: gtp_md(t text)
+ table: gtp_md2(b integer)
+ table: gtp_md2(c date)
+ table: gtp_md3(t text, c date)
+(5 rows)
+
+drop function gtp_err9();
+-- CREATE TABLE AS IF NOT EXISTS - the existing table wins like in
+-- runtime
+create function gtp_err10()
+returns void as $$
+begin
+  create temp table gtp_ine2 as select 1 as a;
+  create temp table if not exists gtp_ine2 as select 'x'::text as b;
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_err10()');
+    plpgsql_make_pragma     
+----------------------------
+ table: gtp_ine2(a integer)
+ table: gtp_ine2(a integer)
+(2 rows)
+
+drop function gtp_err10();
+-- runtime errors of CREATE TABLE statement execution respect
+-- fatal_errors option - a temporary partition of persistent table
+create table gtp_ppart (id int) partition by range (id);
+create function gtp_err7()
+returns void as $$
+begin
+  create temp table gtp_bp partition of gtp_ppart for values from (1) to (100);
+  create temp table gtp_bp2 (id int);
+end;
+$$ language plpgsql;
+do $$
+declare s text; m text;
+begin
+  perform plpgsql_make_pragma('gtp_err7()');
+exception when others then
+  get stacked diagnostics s = returned_sqlstate, m = message_text;
+  raise notice 'sqlstate: %, message: %', s, m;
+end;
+$$;
+NOTICE:  sqlstate: 42809, message: cannot create a temporary relation as partition of permanent relation "gtp_ppart"
+select * from plpgsql_make_pragma('gtp_err7()', fatal_errors => false);
+WARNING:  pragma cannot be generated for statement on line 3
+DETAIL:  cannot create a temporary relation as partition of permanent relation "gtp_ppart"
+    plpgsql_make_pragma     
+----------------------------
+ table: gtp_bp2(id integer)
+(1 row)
+
+drop function gtp_err7();
+drop table gtp_ppart;
+-- more not executable CREATE TABLE statements - foreign key from
+-- temporary table to persistent table, LIKE of missing table, OF
+-- missing type
+create function gtp_err8()
+returns void as $$
+begin
+  create temp table gtp_fk (id int references gtp_src(a));
+  create temp table gtp_bl (like gtp_not_exists);
+  create temp table gtp_bo of gtp_type_not_exists;
+end;
+$$ language plpgsql;
+select * from plpgsql_make_pragma('gtp_err8()', fatal_errors => false);
+WARNING:  pragma cannot be generated for statement on line 3
+DETAIL:  constraints on temporary tables may reference only temporary tables
+WARNING:  pragma cannot be generated for statement on line 4
+DETAIL:  relation "gtp_not_exists" does not exist
+WARNING:  pragma cannot be generated for statement on line 5
+DETAIL:  type "gtp_type_not_exists" does not exist
+ plpgsql_make_pragma 
+---------------------
+(0 rows)
+
+drop function gtp_err8();
 -- "pragmas" option of check functions
 create function gtp_f24()
 returns void as $$

--- a/sql/plpgsql_pragma_generator.sql
+++ b/sql/plpgsql_pragma_generator.sql
@@ -222,13 +222,15 @@ select * from plpgsql_make_pragma('gtp_f13()');
 
 drop function gtp_f13();
 
--- positional processing - same table name twice (no deduplication)
+-- positional processing - same table name twice (no deduplication),
+-- the following statements see the last definition
 create function gtp_f14()
 returns void as $$
 begin
   create temp table gtp_dup as select 1 as x;
   drop table gtp_dup;
   create temp table gtp_dup as select 'a'::text as y;
+  create temp table gtp_dup2 as select * from gtp_dup;
 end;
 $$ language plpgsql;
 
@@ -282,20 +284,18 @@ select * from plpgsql_make_pragma('gtp_f17()');
 
 drop function gtp_f17();
 
--- these forms are ignored - column definition list, LIKE clause,
--- OF type clause, dynamic SQL, not temporary tables and materialized
--- views
+-- these forms are ignored - dynamic SQL, not temporary tables and
+-- materialized views
 create function gtp_f18()
 returns void as $$
 begin
-  create temp table gtp_s1(id int, name text);
-  create temp table gtp_s2(like gtp_src);
-  create temp table gtp_s3 of gtp_ct;
   execute 'create temp table gtp_s4 as select 1 as x';
   create table gtp_s5 as select a from gtp_src;
   create unlogged table gtp_s6 as select a from gtp_src;
+  create table gtp_s8 (id int);
+  create unlogged table gtp_s9 (id int);
   create materialized view gtp_s7 as select a from gtp_src;
-  drop table gtp_s1, gtp_s2, gtp_s3, gtp_s4, gtp_s5, gtp_s6;
+  drop table gtp_s4, gtp_s5, gtp_s6, gtp_s8, gtp_s9;
   drop materialized view gtp_s7;
 end;
 $$ language plpgsql;
@@ -421,6 +421,165 @@ select * from plpgsql_make_pragma('gtp_f23()');
 
 drop function gtp_f23();
 
+-- CREATE TABLE statement based forms. The temporary table is created
+-- inside the check's subtransaction (and removed by its rollback), and
+-- the pragma is derived from the structure of really created table.
+-- Column definition list form - typmods, quoting, serial, identity and
+-- generated columns, constraints, collation (not carried to pragma),
+-- zero columns
+create function gtp_cs1()
+returns void as $$
+begin
+  create temp table gtp_cl1 (id int, name text);
+  create temp table gtp_cl2 (v varchar(10), n numeric(12,2), t text collate "C");
+  create temp table "GtpQ" ("select" int, normal text);
+  create temp table gtp_cl3 (id serial, iid int generated always as identity,
+                             g int generated always as (id + 1) stored);
+  create temp table gtp_cl4 (id int primary key, v text not null default 'x',
+                             check (id > 0));
+  create temp table gtp_cl5 ();
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_cs1()');
+
+drop function gtp_cs1();
+
+-- LIKE clause and OF type clause
+create function gtp_cs2()
+returns void as $$
+begin
+  create temp table gtp_lk1 (like gtp_src);
+  create temp table gtp_lk2 (like gtp_src including all);
+  create temp table gtp_lk3 (id int, like gtp_src);
+  create temp table gtp_of1 of gtp_ct;
+  create temp table gtp_of2 of gtp_ct (x with options not null);
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_cs2()');
+
+drop function gtp_cs2();
+
+-- inheritance - from a persistent table and from a temporary table
+-- created earlier in same function
+create table gtp_parent(pid int, pval text);
+
+create function gtp_cs3()
+returns void as $$
+begin
+  create temp table gtp_inh1 () inherits (gtp_parent);
+  create temp table gtp_inh2 (own text) inherits (gtp_parent);
+  create temp table gtp_tp (a int, b text);
+  create temp table gtp_inh3 () inherits (gtp_tp);
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_cs3()');
+
+drop function gtp_cs3();
+drop table gtp_parent;
+
+-- partitioning - temporary parent and temporary partitions
+create function gtp_cs4()
+returns void as $$
+begin
+  create temp table gtp_pp (id int, v text) partition by range (id);
+  create temp table gtp_p1 partition of gtp_pp for values from (1) to (100);
+  create temp table gtp_p2 partition of gtp_pp default;
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_cs4()');
+
+drop function gtp_cs4();
+
+-- storage options, access method, ON COMMIT variants, IF NOT EXISTS
+-- (the existing table wins - like runtime does), pg_temp qualification
+-- without TEMP keyword
+create function gtp_cs5()
+returns void as $$
+begin
+  create temp table gtp_o1 (a int) with (fillfactor = 70);
+  create temp table gtp_o2 (a int) using heap;
+  create temp table gtp_o3 (a int) on commit preserve rows;
+  create temp table gtp_o4 (a int) on commit delete rows;
+  create temp table gtp_o5 (a int) on commit drop;
+  create temp table if not exists gtp_o6 (a int);
+  create temp table if not exists gtp_o6 (b text);
+  create table pg_temp.gtp_o7 (a int);
+  create table pg_temp.gtp_o8 (like gtp_src);
+  create table pg_temp.gtp_o9 of gtp_ct;
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_cs5()');
+
+drop function gtp_cs5();
+
+-- mixed CREATE TABLE AS and CREATE TABLE statements
+create function gtp_mx1()
+returns void as $$
+begin
+  create temp table gtp_mm1 as select a, b from gtp_src;
+  create temp table gtp_mm2 (id int, v text);
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_mx1()');
+
+drop function gtp_mx1();
+
+-- the table created by CREATE TABLE statement is visible for the
+-- following CREATE TABLE AS statements (join, subquery)
+create function gtp_mx2()
+returns void as $$
+begin
+  create temp table gtp_mn1 (a int, b text);
+  create temp table gtp_mn2 as
+    select gtp_mn1.a, s.b from gtp_mn1 join gtp_src s on s.a = gtp_mn1.a
+    where gtp_mn1.a in (select a from gtp_mn1);
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_mx2()');
+
+drop function gtp_mx2();
+
+-- and the reverse order - the table created by CREATE TABLE AS
+-- statement is visible for the following CREATE TABLE statement
+create function gtp_mx3()
+returns void as $$
+begin
+  create temp table gtp_mo1 as select a, b from gtp_src;
+  create temp table gtp_mo2 (like gtp_mo1 including all);
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_mx3()');
+
+drop function gtp_mx3();
+
+-- generator of CREATE TABLE statement based pragmas is idempotent too
+create function gtp_cs6()
+returns void as $$
+begin
+  create temp table gtp_ii (id int, v text);
+  insert into gtp_ii values (1, 'x');
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_cs6()');
+select * from plpgsql_make_pragma('gtp_cs6()');
+
+select count(*) from pg_class where relname in ('gtp_ii');
+
+-- generated pragma is usable by "pragmas" option
+select * from plpgsql_check_function('gtp_cs6()',
+          pragmas => array(select plpgsql_make_pragma('gtp_cs6()')));
+
+drop function gtp_cs6();
+
 -- error cases
 create function gtp_err1()
 returns void as $$
@@ -495,8 +654,9 @@ $$;
 
 drop function gtp_err3();
 
--- same check is done for ignored forms too (column definition list,
--- LIKE clause, OF type clause), and it respects fatal_errors option
+-- the check of target schema is done before execution for CREATE TABLE
+-- statement forms too (column definition list, LIKE clause, OF type
+-- clause), and it respects fatal_errors option
 create function gtp_err4()
 returns void as $$
 begin
@@ -540,6 +700,102 @@ end;
 $$;
 
 drop function gtp_err5();
+
+-- duplicate table name (usually the pattern CREATE, DROP, CREATE with
+-- same name) is reported as warning only - DROP statements are not
+-- executed by static scanning, so this is not a real error. Pragmas
+-- are returned for both definitions, and the following statements see
+-- the last definition.
+create function gtp_err6()
+returns void as $$
+begin
+  create temp table gtp_dd (x int);
+  drop table gtp_dd;
+  create temp table gtp_dd (y text);
+  create temp table gtp_dd2 (z int);
+  create temp table gtp_dd3 as select * from gtp_dd;
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_err6()');
+
+drop function gtp_err6();
+
+-- mixed collisions - CREATE TABLE statement redefined by CREATE TABLE
+-- AS statement and vice versa
+create function gtp_err9()
+returns void as $$
+begin
+  create temp table gtp_md (a int);
+  drop table gtp_md;
+  create temp table gtp_md as select 'x'::text as t;
+  create temp table gtp_md2 as select 1 as b;
+  drop table gtp_md2;
+  create temp table gtp_md2 (c date);
+  create temp table gtp_md3 as select * from gtp_md, gtp_md2;
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_err9()');
+
+drop function gtp_err9();
+
+-- CREATE TABLE AS IF NOT EXISTS - the existing table wins like in
+-- runtime
+create function gtp_err10()
+returns void as $$
+begin
+  create temp table gtp_ine2 as select 1 as a;
+  create temp table if not exists gtp_ine2 as select 'x'::text as b;
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_err10()');
+
+drop function gtp_err10();
+
+-- runtime errors of CREATE TABLE statement execution respect
+-- fatal_errors option - a temporary partition of persistent table
+create table gtp_ppart (id int) partition by range (id);
+
+create function gtp_err7()
+returns void as $$
+begin
+  create temp table gtp_bp partition of gtp_ppart for values from (1) to (100);
+  create temp table gtp_bp2 (id int);
+end;
+$$ language plpgsql;
+
+do $$
+declare s text; m text;
+begin
+  perform plpgsql_make_pragma('gtp_err7()');
+exception when others then
+  get stacked diagnostics s = returned_sqlstate, m = message_text;
+  raise notice 'sqlstate: %, message: %', s, m;
+end;
+$$;
+
+select * from plpgsql_make_pragma('gtp_err7()', fatal_errors => false);
+
+drop function gtp_err7();
+drop table gtp_ppart;
+
+-- more not executable CREATE TABLE statements - foreign key from
+-- temporary table to persistent table, LIKE of missing table, OF
+-- missing type
+create function gtp_err8()
+returns void as $$
+begin
+  create temp table gtp_fk (id int references gtp_src(a));
+  create temp table gtp_bl (like gtp_not_exists);
+  create temp table gtp_bo of gtp_type_not_exists;
+end;
+$$ language plpgsql;
+
+select * from plpgsql_make_pragma('gtp_err8()', fatal_errors => false);
+
+drop function gtp_err8();
 
 -- "pragmas" option of check functions
 create function gtp_f24()

--- a/src/pragma_generator.c
+++ b/src/pragma_generator.c
@@ -2,7 +2,7 @@
  *
  * pragma_generator.c
  *
- *			  generator of table pragmas for CREATE TEMP TABLE AS
+ *			  generator of table pragmas for CREATE TEMP TABLE
  *			  statements used in function's body
  *
  * by Pavel Stehule 2013-2026
@@ -12,18 +12,26 @@
 
 #include "plpgsql_check.h"
 
+#include "access/table.h"
+#include "catalog/namespace.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_type.h"
 #include "nodes/nodeFuncs.h"
 #include "parser/parser.h"
 #include "utils/builtins.h"
+#include "utils/rel.h"
 
 static void make_pragma_stmt_walker(PLpgSQL_stmt *stmt, void *context);
 static void process_stmt_query(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt,
 							   PLpgSQL_expr *expr, bool is_perform_stmt);
 static void process_create_table_as(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt,
 									PLpgSQL_expr *expr, CreateTableAsStmt *ctas);
+static void process_create_table(PLpgSQL_checkstate *cstate, PLpgSQL_expr *expr,
+								 CreateStmt *cstmt);
 static char *build_table_pragma_def(const char *relname, List *colNames, List *targetList);
+static char *build_table_pragma_def_from_tupdesc(const char *relname, TupleDesc tupdesc);
+static void emit_pragma_from_relid(PLpgSQL_checkstate *cstate, Oid relid);
+static void drop_temp_table(const char *relname);
 static bool is_temp_range_var(RangeVar *rel);
 static void check_temp_schema(RangeVar *rel);
 
@@ -127,6 +135,84 @@ build_table_pragma_def(const char *relname, List *colNames, List *targetList)
 }
 
 /*
+ * Returns definition of a table (usable by table pragma) derived from
+ * a tuple descriptor of an existing relation.
+ */
+static char *
+build_table_pragma_def_from_tupdesc(const char *relname, TupleDesc tupdesc)
+{
+	StringInfoData def;
+	bool		is_first = true;
+	int			i;
+
+	initStringInfo(&def);
+	appendStringInfo(&def, "%s(", quote_identifier(relname));
+
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+
+		if (att->attisdropped)
+			continue;
+
+		if (!is_first)
+			appendStringInfoString(&def, ", ");
+
+		appendStringInfo(&def, "%s %s",
+						 quote_identifier(NameStr(att->attname)),
+						 format_type_with_typemod(att->atttypid, att->atttypmod));
+
+		is_first = false;
+	}
+
+	appendStringInfoChar(&def, ')');
+
+	return def.data;
+}
+
+/*
+ * Emits the table pragma derived from the structure of an existing
+ * relation.
+ */
+static void
+emit_pragma_from_relid(PLpgSQL_checkstate *cstate, Oid relid)
+{
+	Relation	rel;
+	char	   *def;
+
+	rel = table_open(relid, AccessShareLock);
+
+	def = build_table_pragma_def_from_tupdesc(RelationGetRelationName(rel),
+											  RelationGetDescr(rel));
+
+	table_close(rel, AccessShareLock);
+
+	plch_put_text_line(cstate->result_info,
+					   psprintf("table: %s", def), -1);
+}
+
+/*
+ * A name collision (usually the pattern CREATE, DROP, CREATE with same
+ * name) is an artifact of static scanning - DROP statements are not
+ * executed. We want to return pragmas for both definitions, so the
+ * previous table is dropped (the drop is reverted by rollback of the
+ * check's subtransaction), and the following statements will see the
+ * last definition like in runtime.
+ */
+static void
+drop_temp_table(const char *relname)
+{
+	ereport(WARNING,
+			(errcode(ERRCODE_DUPLICATE_TABLE),
+			 errmsg("relation \"%s\" already exists", relname),
+			 errdetail("The temporary table is replaced by the new definition.")));
+
+	if (SPI_execute(psprintf("DROP TABLE pg_temp.%s", quote_identifier(relname)),
+					false, 0) != SPI_OK_UTILITY)
+		elog(ERROR, "unexpected SPI result on DROP TABLE execution");
+}
+
+/*
  * Generates (and returns as a result row) the table pragma for one
  * CREATE TEMP TABLE AS statement. The pragma is applied immediately
  * too, so the temporary table is visible for planning of the following
@@ -140,6 +226,7 @@ process_create_table_as(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt,
 	CreateTableAsStmt *ctas_analyzed;
 	Query	   *query;
 	Query	   *inner_query;
+	Oid			relid;
 	char	   *def;
 
 	/* materialized views cannot be temporary */
@@ -187,11 +274,62 @@ process_create_table_as(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt,
 								 ctas->into->colNames,
 								 inner_query->targetList);
 
+	relid = RangeVarGetRelid(ctas->into->rel, NoLock, true);
+	if (OidIsValid(relid))
+	{
+		/* like runtime does, the existing table wins */
+		if (ctas->if_not_exists)
+		{
+			emit_pragma_from_relid(cstate, relid);
+			return;
+		}
+
+		drop_temp_table(ctas->into->rel->relname);
+	}
+
 	plch_put_text_line(cstate->result_info,
 					   psprintf("table: %s", def), -1);
 
 	/* make the temporary table visible for following statements */
 	plpgsql_check_pragma_table(cstate, def, stmt->lineno);
+}
+
+/*
+ * Generates (and returns as a result row) the table pragma for one
+ * CREATE TEMP TABLE statement - the column definition list form, the
+ * LIKE clause, the OF type clause, inheritance or partitioning. The
+ * original statement is executed - the temporary table is created
+ * inside the check's subtransaction, that is always rolled back, so
+ * no object survives the check. The execution is the only reliable
+ * way how to get the table's structure - the LIKE clause, the OF type
+ * clause, inheritance, partitioning or serial columns are expanded by
+ * PostgreSQL itself. Unlike the CREATE TABLE AS branch, the pragma is
+ * not applied here - the table already exists, and it is visible for
+ * planning of the following statements.
+ */
+static void
+process_create_table(PLpgSQL_checkstate *cstate, PLpgSQL_expr *expr,
+					 CreateStmt *cstmt)
+{
+	Oid			relid;
+
+	if (!is_temp_range_var(cstmt->relation))
+		return;
+
+	check_temp_schema(cstmt->relation);
+
+	relid = RangeVarGetRelid(cstmt->relation, NoLock, true);
+	if (OidIsValid(relid) && !cstmt->if_not_exists)
+		drop_temp_table(cstmt->relation->relname);
+
+	if (SPI_execute(expr->query, false, 0) != SPI_OK_UTILITY)
+		elog(ERROR, "unexpected SPI result on CREATE TABLE execution");
+
+	relid = RangeVarGetRelid(cstmt->relation, NoLock, true);
+	if (!OidIsValid(relid))
+		return;
+
+	emit_pragma_from_relid(cstate, relid);
 }
 
 /*
@@ -236,16 +374,7 @@ process_stmt_query(PLpgSQL_checkstate *cstate, PLpgSQL_stmt *stmt,
 			}
 			else if (IsA(node, CreateStmt))
 			{
-				CreateStmt *cstmt = (CreateStmt *) node;
-
-				/*
-				 * The table pragma cannot be generated from CREATE TABLE
-				 * statement (column definition list, LIKE clause or OF type
-				 * clause), but the check of target schema should be done
-				 * every time.
-				 */
-				if (is_temp_range_var(cstmt->relation))
-					check_temp_schema(cstmt->relation);
+				process_create_table(cstate, expr, (CreateStmt *) node);
 			}
 			else if (IsA(node, SelectStmt))
 			{
@@ -320,7 +449,7 @@ make_pragma_stmt_walker(PLpgSQL_stmt *stmt, void *context)
 
 /*
  * Scans the function's body and generates (and returns as result rows)
- * table pragmas for all CREATE TEMP TABLE AS statements there.
+ * table pragmas for all statements there that create temporary tables.
  */
 void
 plch_make_pragma(PLpgSQL_checkstate *cstate, PLpgSQL_function *func)


### PR DESCRIPTION
## Motivation

This is the follow-up promised in #212. Until now `plpgsql_make_pragma` processed only
`CREATE TEMP TABLE ... AS SELECT|VALUES|TABLE` statements. The `CREATE TABLE` statement
based forms of temporary tables were skipped - only the target schema check (`42P16`) was
done for them. Now the table pragmas are generated for these forms too:

* column definition list - `CREATE TEMP TABLE t (id int, name text);`
* `CREATE TEMP TABLE t (LIKE src INCLUDING ALL);`
* `CREATE TEMP TABLE t OF my_type;`
* inheritance - `CREATE TEMP TABLE t (...) INHERITS (parent);`
* partitioning - `PARTITION BY` on a temporary parent and
  `CREATE TEMP TABLE t PARTITION OF temp_parent FOR VALUES ...` / `DEFAULT`
* all variations: serial, identity and generated columns, constraints, storage
  parameters (`WITH (...)`), access method (`USING`), `ON COMMIT` variants,
  `IF NOT EXISTS`, and the `pg_temp` schema qualification used without the `TEMP`
  keyword (`CREATE TABLE pg_temp.t (...)`)

## How it works

The structure of these tables cannot be derived by planning - the expansion of the LIKE
clause, inheritance, partitioning or serial columns is a job of PostgreSQL itself. So the
statement is **executed** - the temporary table is created inside the check's
subtransaction, which is always rolled back, and the pragma is derived from the structure
of the really created table (a new renderer walks the TupleDesc). This is the same trick
that the `table:` pragma mechanism already uses (`plpgsql_check_pragma_table` executes
`CREATE TEMP TABLE ...` via SPI in the same subtransaction), so the trust level doesn't
change.

The invariants of the generator hold:

* no object survives the call - everything is removed by the rollback of the check's
  subtransaction (pinned by a regress test that counts `pg_class` rows before/after),
* repeated calls return the same result (idempotence),
* the target schema check (`42P16`) is done before the execution,
* execution errors are the same as runtime errors (e.g. a temporary partition of a
  persistent table, a foreign key from a temporary table to a persistent table, `LIKE`
  of a missing table) and respect the `fatal_errors` option,
* the output stays a clean list of pragmas usable by the `pragmas` option.

Example:

    create function fx()
    returns void as $$
    begin
      create temp table xx (id serial, v varchar(10));
      create temp table yy (like xx including all);
      insert into yy(v) values ('hello');
    end;
    $$ language plpgsql;

    select * from plpgsql_make_pragma('fx()');
    -- table: xx(id integer, v character varying(10))
    -- table: yy(id integer, v character varying(10))

Because the tables are really created, the mixed chains work in both directions: a
`CREATE TABLE` statement based table is visible when the following `CREATE TABLE AS`
statements are planned (joins, subqueries), and a `CREATE TABLE AS` based table (created
by the pragma registration) is visible for the following `LIKE` / `INHERITS` /
`PARTITION OF` clauses.

## Behavioural change: unified name collision handling (affects the CTAS path too)

The behaviour on a name collision (usually the valid
runtime pattern `CREATE`, `DROP`, `CREATE` with the same name - static scanning doesn't
execute DROP statements) is now identical for both `CreateStmt` and `CreateTableAsStmt`
statements:

* a warning is raised: `relation "..." already exists` with the detail
  `The temporary table is replaced by the new definition.`,
* the previous table is dropped (the drop is reverted by the rollback of the check's
  subtransaction) and the new definition is created/registered,
* pragmas are returned for **both** definitions,
* the following statements of the function's body see the **last** definition - like in
  runtime.

Previously the two paths differed: the CTAS path returned both pragmas, but the
registration of the second one failed with the pragma mechanism's warning
(`Pragma "table" ... is not processed.`), and the following statements saw the **first**
definition; the CreateStmt path could not return the second pragma at all.

Related unification: `CREATE TEMP TABLE IF NOT EXISTS` over an existing table returns
the structure of the **existing** table in both paths (the existing table wins - like in
runtime). For the CTAS path this is also a small behavioural change - previously the
pragma was derived from the inner query even when the table already existed.

## Implementation notes

* All changes are inside `src/pragma_generator.c` - new static helpers
  `process_create_table` (executes the statement and emits the pragma),
  `build_table_pragma_def_from_tupdesc` (renders a column list from a TupleDesc,
  skipping dropped attributes), `emit_pragma_from_relid` and `drop_temp_table`
  (the shared collision handling). No new exported symbols, no new typedefs.
* This is not an SQL API change - the extension version is not touched.
* Column constraints (`PRIMARY KEY`, `NOT NULL`, `DEFAULT`, `CHECK`) don't block the
  generation, but they are not carried into the generated pragma - the pragma holds only
  column names and types, which is enough for the static checks (pinned by a regress
  test). Column `COLLATE` is not carried over either. Note that this matches the manual
  `table:` pragma parser, which accepts only "name type" column lists - constraints or
  `COLLATE` clauses written there by hand are rejected.
* Temporary sequences still have to be declared manually; dynamic SQL,
  `CREATE TABLE ... AS EXECUTE` and tables created in called routines remain out of
  scope.

## Testing

* The regress test `plpgsql_pragma_generator` got new cases: all `CREATE TABLE`
  statement forms and variations listed above (incl. quoting, typmods, collation not
  carried over, zero-column table, `pg_temp` qualification), mixed
  `CreateStmt`/`CreateTableAsStmt` functions with references in both directions
  (join/subquery and `LIKE`), name collisions for both paths and for the mixed order
  with a "witness" table proving that the last definition is visible, `IF NOT EXISTS`
  over an existing table for both paths, error cases with pinned SQLSTATEs and
  `fatal_errors => false` branches, idempotence with the `pg_class` before/after check,
  and the end-to-end usage via the `pragmas` option. The old "ignored forms" block was
  reduced to the really ignored statements (dynamic SQL, not temporary tables,
  materialized views).
* The README section "Table pragmas generator" is updated - the obsolete limitations
  are removed, the new forms, the example and the collision behaviour are documented.
  The "Supported pragmas" section now states explicitly that the column list of the
  `table:` pragma supports only a column name and a type (no constraints, no `COLLATE`),
  and the generator section explains that constraints are executed but not carried into
  the generated pragma.
* Verified locally on PostgreSQL 18.4 - the full installcheck (all 6 tests) is green.
  PG 14-17 is covered by CI here; the error messages pinned in the expected file come
  from the server runtime, so if some of them drift between versions, I'm ready to add
  alternative expected files.
* cppcheck and pgindent were run over the changed code.
