### PR TITLE
fix leftover references to renamed pragma generator regress test

### DIFF
--- a/expected/README
+++ b/expected/README
@@ -5,4 +5,4 @@ plpgsql_check_active_3.out			PostgreSQL 18
 plpgsql_check_active_4.out			PostgreSQL 19
 plpgsql_check_active.out			PostgreSQL 17
 
-plch_pragma_generator.out		PostgreSQL 14 and higher (all versions)
+plpgsql_pragma_generator.out		PostgreSQL 14 and higher (all versions)

--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,7 @@ tests = [ 'plpgsql_check_active',
           'plpgsql_check_passive',
           'plpgsql_check_active-'  + pg_version_major.to_string(),
           'plpgsql_check_passive-' + pg_version_major.to_string(),
-          'plch_pragma_generator' ]
+          'plpgsql_pragma_generator' ]
 
 compiler = meson.get_compiler('c')
 


### PR DESCRIPTION
After the test was renamed to `plpgsql_pragma_generator`, `meson.build` and `expected/README` still pointed to the nonexistent `plch_pragma_generator`, so the meson test run (`ninja test`) could not find the test input.