### PR TITLE
Fix crash in plpgsql_show_dependency_tb on trigger functions

### DIFF
--- a/expected/plpgsql_check_active.out
+++ b/expected/plpgsql_check_active.out
@@ -3268,6 +3268,26 @@ select type, schema, name from plpgsql_show_dependency_tb('testfuncdep');
 drop function testfuncdep();
 drop type foo_type;
 drop table foo;
+-- issue #221 - dependency report on trigger function should not crash
+-- (NEW and OLD record variables have no datatype)
+create table foo(a int, b text);
+create function foo_trg_func()
+returns trigger as $$
+begin
+  new.b := 'x';
+  return new;
+end;
+$$ language plpgsql;
+create trigger foo_trg before insert on foo
+  for each row execute function foo_trg_func();
+select type, schema, name from plpgsql_show_dependency_tb('foo_trg_func', 'foo');
+ type | schema | name 
+------+--------+------
+(0 rows)
+
+drop trigger foo_trg on foo;
+drop function foo_trg_func();
+drop table foo;
 -- issue #34
 create or replace function testcase()
 returns bool as $$

--- a/expected/plpgsql_check_active_2.out
+++ b/expected/plpgsql_check_active_2.out
@@ -3267,6 +3267,26 @@ select type, schema, name from plpgsql_show_dependency_tb('testfuncdep');
 drop function testfuncdep();
 drop type foo_type;
 drop table foo;
+-- issue #221 - dependency report on trigger function should not crash
+-- (NEW and OLD record variables have no datatype)
+create table foo(a int, b text);
+create function foo_trg_func()
+returns trigger as $$
+begin
+  new.b := 'x';
+  return new;
+end;
+$$ language plpgsql;
+create trigger foo_trg before insert on foo
+  for each row execute function foo_trg_func();
+select type, schema, name from plpgsql_show_dependency_tb('foo_trg_func', 'foo');
+ type | schema | name 
+------+--------+------
+(0 rows)
+
+drop trigger foo_trg on foo;
+drop function foo_trg_func();
+drop table foo;
 -- issue #34
 create or replace function testcase()
 returns bool as $$

--- a/expected/plpgsql_check_active_3.out
+++ b/expected/plpgsql_check_active_3.out
@@ -3268,6 +3268,26 @@ select type, schema, name from plpgsql_show_dependency_tb('testfuncdep');
 drop function testfuncdep();
 drop type foo_type;
 drop table foo;
+-- issue #221 - dependency report on trigger function should not crash
+-- (NEW and OLD record variables have no datatype)
+create table foo(a int, b text);
+create function foo_trg_func()
+returns trigger as $$
+begin
+  new.b := 'x';
+  return new;
+end;
+$$ language plpgsql;
+create trigger foo_trg before insert on foo
+  for each row execute function foo_trg_func();
+select type, schema, name from plpgsql_show_dependency_tb('foo_trg_func', 'foo');
+ type | schema | name 
+------+--------+------
+(0 rows)
+
+drop trigger foo_trg on foo;
+drop function foo_trg_func();
+drop table foo;
 -- issue #34
 create or replace function testcase()
 returns bool as $$

--- a/expected/plpgsql_check_active_4.out
+++ b/expected/plpgsql_check_active_4.out
@@ -3267,6 +3267,26 @@ select type, schema, name from plpgsql_show_dependency_tb('testfuncdep');
 drop function testfuncdep();
 drop type foo_type;
 drop table foo;
+-- issue #221 - dependency report on trigger function should not crash
+-- (NEW and OLD record variables have no datatype)
+create table foo(a int, b text);
+create function foo_trg_func()
+returns trigger as $$
+begin
+  new.b := 'x';
+  return new;
+end;
+$$ language plpgsql;
+create trigger foo_trg before insert on foo
+  for each row execute function foo_trg_func();
+select type, schema, name from plpgsql_show_dependency_tb('foo_trg_func', 'foo');
+ type | schema | name 
+------+--------+------
+(0 rows)
+
+drop trigger foo_trg on foo;
+drop function foo_trg_func();
+drop table foo;
 -- issue #34
 create or replace function testcase()
 returns bool as $$

--- a/sql/plpgsql_check_active.sql
+++ b/sql/plpgsql_check_active.sql
@@ -2398,6 +2398,27 @@ drop function testfuncdep();
 drop type foo_type;
 drop table foo;
 
+-- issue #221 - dependency report on trigger function should not crash
+-- (NEW and OLD record variables have no datatype)
+create table foo(a int, b text);
+
+create function foo_trg_func()
+returns trigger as $$
+begin
+  new.b := 'x';
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger foo_trg before insert on foo
+  for each row execute function foo_trg_func();
+
+select type, schema, name from plpgsql_show_dependency_tb('foo_trg_func', 'foo');
+
+drop trigger foo_trg on foo;
+drop function foo_trg_func();
+drop table foo;
+
 -- issue #34
 create or replace function testcase()
 returns bool as $$

--- a/src/check_function.c
+++ b/src/check_function.c
@@ -135,6 +135,10 @@ reports_used_rowtypes_dependency(PLpgSQL_function *func, PLpgSQL_checkstate *cst
 			Oid		typrelid;
 			char	relkind;
 
+			/* datatype can be NULL, when rectypeid is RECORDOID (trigger NEW/OLD) */
+			if (!rec->datatype)
+				continue;
+
 			typrelid = get_typ_typrelid(rec->datatype->typoid);
 			relkind = get_rel_relkind(typrelid);
 


### PR DESCRIPTION
Follow-up to #221: `reports_used_rowtypes_dependency()` dereferences `rec->datatype`, which is NULL for trigger `NEW`/`OLD` records (`plpgsql.h`: *"can be NULL, if rectypeid is RECORDOID"*). Calling `plpgsql_show_dependency_tb` on any trigger function segfaults the backend at `check_function.c:138`.

Skips record datums with no datatype, and adds a regress test — the suite previously never ran the dependency report on a trigger function. Verified on PostgreSQL 18.3, `make installcheck` 6/6.